### PR TITLE
utils.rs:Fix readdir file type problem

### DIFF
--- a/src/implementation/utils.rs
+++ b/src/implementation/utils.rs
@@ -6,6 +6,18 @@ use {
     tokio::fs,
 };
 
+fn file_type_to_byte(file_type: &std::fs::FileType) -> u8 {
+    if file_type.is_file() {
+        0x08
+    } else if file_type.is_dir() {
+        0x04
+    } else if file_type.is_symlink() {
+        0x12
+    } else {
+        0x00
+    }
+}
+
 pub fn create_buffer(size: usize) -> Vec<u8> {
     let mut buffer = Vec::with_capacity(size);
     unsafe {
@@ -50,7 +62,7 @@ pub async fn get_dirent(
     Ok(DirEntry {
         qid: qid_from_attr(&entry.metadata().await?, va),
         offset: offset,
-        typ: 0,
+        typ: file_type_to_byte(&entry.file_type().await?),
         name: entry.file_name().to_string_lossy().into_owned(),
     })
 }


### PR DESCRIPTION
  Hello, I found the problem that when traversing each entry through readdir and getting the type of the entry, it always returns 0.

  So I changed the setting of typ in "get_dirent" according to your code. Now it is able to distinguish between file/folder/symlink types.

  Local Environment Linux Authentication Problem Solving